### PR TITLE
Set linux execute bit on @pnpm/exe binary

### DIFF
--- a/beta-install.sh
+++ b/beta-install.sh
@@ -84,6 +84,7 @@ download_and_install() {
   ohai 'Extracting pnpm binaries'
   # extract the files to the specified directory
   download "$archive_url" | tar -xz -C "$tmp_dir" --strip-components=1 || return 1
+  chmod +x "$tmp_dir/pnpm"
   SHELL="$SHELL" "$tmp_dir/pnpm" setup || return 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,7 @@ download_and_install() {
   ohai "Extracting pnpm binaries ${version}"
   # extract the files to the specified directory
   download "$archive_url" | tar -xz -C "$tmp_dir" --strip-components=1 || return 1
+  chmod +x "$tmp_dir/pnpm"
   SHELL="$SHELL" "$tmp_dir/pnpm" setup || return 1
 }
 


### PR DESCRIPTION
I tried the following, and met an error. This PR simply makes sure the execute bit is set on the `pnpm` binary used for setup prior to attempting to execute it.

`curl -fsSL https://get.pnpm.io/install.sh | PNPM_VERSION=7.0.0-alpha.1 sh -`

```
==> Extracting pnpm binaries 7.0.0-alpha.1
sh: 104: /tmp/tmp.u8eIGnf06q/pnpm: Permission denied
Install Error!
```

Unrelated, but I also noticed that `PNPM_VERSION=next` and `PNPM_VERSION=next-7` did not work, but the README makes it seem like `next` would work. I had to specify the exact version number to not reach a 404 error.