### PR TITLE
Fix Windows Installation

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -119,7 +119,7 @@ if ($null -eq $version) {
 Write-Host "Downloading pnpm from GitHub...`n" -ForegroundColor Green
 
 $tempFileFolder = New-TemporaryDirectory
-$tempFile = (Join-Path $tempFileFolder.FullName "pnpm")
+$tempFile = (Join-Path $tempFileFolder.FullName $pnpmName)
 $archiveUrl="https://github.com/pnpm/pnpm/releases/download/v$version/pnpm-$platform-$architecture"
 if ($platform -eq 'win') {
   $archiveUrl="$archiveUrl.exe"


### PR DESCRIPTION
There is an issue where running the install script on a windows machine will not put ".exe" at the end of the binary, resulting in issues when trying to run it.  This small change fixes that.