### PR TITLE
docs: show how to verify the installer before running it

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,34 +39,48 @@ curl -fsSLO https://get.pnpm.io/SHASUMS256.txt.sig
 # Import the pnpm release key (compare the fingerprint with the one below)
 curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/4D20AD76D7BE567214F3F8EE4EABAE7510A044FA | gpg --import
 
-gpg --verify SHASUMS256.txt.sig SHASUMS256.txt
-grep ' install.sh$' SHASUMS256.txt | sha256sum -c -   # on macOS: shasum -a 256 -c -
-
-sh install.sh
+gpg --verify SHASUMS256.txt.sig SHASUMS256.txt \
+  && grep ' install.sh$' SHASUMS256.txt | sha256sum -c - \
+  && sh install.sh
 ```
 
-The first check prints `Good signature`, followed by the key's user IDs; the second prints
-`install.sh: OK`. Run the installer only if both pass.
+The steps are chained, so the installer does not run unless both checks pass. The first
+prints `Good signature`, followed by the key's user IDs; the second prints `install.sh: OK`.
+
+macOS has no `sha256sum` — use `shasum -a 256 -c -` in its place.
 
 `gpg` also prints `WARNING: The key's User ID is not certified with a trusted signature`.
 That is expected — it only means you have not personally certified the key. What
 establishes trust is the fingerprint, so compare the one `gpg` reports against the
 fingerprint published here.
 
-On Windows (PowerShell):
+On Windows (PowerShell). `gpg` is not part of Windows — [Gpg4win](https://gpg4win.org)
+provides it:
 
 ```powershell
 iwr https://get.pnpm.io/install.ps1 -OutFile install.ps1
 iwr https://get.pnpm.io/SHASUMS256.txt -OutFile SHASUMS256.txt
+iwr https://get.pnpm.io/SHASUMS256.txt.sig -OutFile SHASUMS256.txt.sig
+
+# Import the pnpm release key (compare the fingerprint with the one below)
+iwr https://keys.openpgp.org/vks/v1/by-fingerprint/4D20AD76D7BE567214F3F8EE4EABAE7510A044FA -OutFile pnpm.asc
+gpg --import pnpm.asc
+
+gpg --verify SHASUMS256.txt.sig SHASUMS256.txt
+if ($LASTEXITCODE -ne 0) { throw 'SHASUMS256.txt is not signed by the pnpm release key' }
 
 $expected = (Select-String -Path SHASUMS256.txt -Pattern ' install\.ps1$').Line.Split(' ')[0]
-(Get-FileHash install.ps1 -Algorithm SHA256).Hash -eq $expected.ToUpper()
+if ((Get-FileHash install.ps1 -Algorithm SHA256).Hash -ne $expected.ToUpper()) {
+  throw 'install.ps1 does not match its published checksum'
+}
 
 .\install.ps1
 ```
 
-The comparison prints `True` if the script matches. To also check the signature, install
-[Gpg4win](https://gpg4win.org) and run the same `gpg --verify` command as above.
+Both checks stop the script rather than fall through to the installer. Skipping the
+signature step is not equivalent to running it: the checksums are served from the same
+site as the installer, so on their own they only prove the two files agree with each
+other. The signature is what ties them to the pnpm release key.
 
 ### The pnpm release key
 
@@ -83,8 +97,9 @@ source works:
 curl -fsSL https://keybase.io/pnpm/pgp_keys.asc | gpg --import
 ```
 
-`SHASUMS256.txt` covers the installer scripts served from this site. The pnpm executable
-itself is downloaded by the installer from the pnpm release for the version being installed.
+`SHASUMS256.txt` lists the installer scripts served from this site — `install.sh`,
+`install.ps1`, and the legacy `v6*.js` installers. It does not cover the pnpm executable,
+which the installer downloads from the pnpm release for the version being installed.
 
 ## Configuring
 

--- a/README.md
+++ b/README.md
@@ -20,40 +20,71 @@ On Windows (PowerShell):
 iwr https://get.pnpm.io/install.ps1 -useb | iex
 ```
 
+These commands run the installer as soon as it is downloaded. To check that it is
+the script pnpm published before running it, see [Verifying files](#verifying-files).
+
 ## Verifying files
 
-To download `SHASUMS256.txt` using curl:
+The installer scripts served from this site are listed in [`SHASUMS256.txt`](https://get.pnpm.io/SHASUMS256.txt),
+which is signed with the pnpm release key. Verifying takes two steps: check that the
+checksum file carries a good signature, then check the script against its checksum.
+
+On POSIX systems:
 
 ```sh
-curl -O https://get.pnpm.io/SHASUMS256.txt
-```
+curl -fsSLO https://get.pnpm.io/install.sh
+curl -fsSLO https://get.pnpm.io/SHASUMS256.txt
+curl -fsSLO https://get.pnpm.io/SHASUMS256.txt.sig
 
-To check that a downloaded file matches the checksum, run it through sha256sum with a command such as:
+# Import the pnpm release key (compare the fingerprint with the one below)
+curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/4D20AD76D7BE567214F3F8EE4EABAE7510A044FA | gpg --import
 
-```sh
-grep v6.16.js SHASUMS256.txt | sha256sum -c -
-```
-
-The GPG detached signature of `SHASUMS256.txt` is in `SHASUMS256.txt.sig`.
-You can use it with `gpg` to verify the integrity of `SHASUMS256.txt`.
-You will first need to import the GPG keys of individuals authorized to create releases.
-To import the keys:
-
-```sh
-curl https://keybase.io/pnpm/pgp_keys.asc | gpg --import
-```
-
-Next, download the `SHASUMS256.txt.sig`:
-
-```sh
-curl -O https://get.pnpm.io/SHASUMS256.txt.sig
-```
-
-Then use the following script to verify the file's signature:
-
-```sh
 gpg --verify SHASUMS256.txt.sig SHASUMS256.txt
+grep ' install.sh$' SHASUMS256.txt | sha256sum -c -   # on macOS: shasum -a 256 -c -
+
+sh install.sh
 ```
+
+The first check prints `Good signature`, followed by the key's user IDs; the second prints
+`install.sh: OK`. Run the installer only if both pass.
+
+`gpg` also prints `WARNING: The key's User ID is not certified with a trusted signature`.
+That is expected — it only means you have not personally certified the key. What
+establishes trust is the fingerprint, so compare the one `gpg` reports against the
+fingerprint published here.
+
+On Windows (PowerShell):
+
+```powershell
+iwr https://get.pnpm.io/install.ps1 -OutFile install.ps1
+iwr https://get.pnpm.io/SHASUMS256.txt -OutFile SHASUMS256.txt
+
+$expected = (Select-String -Path SHASUMS256.txt -Pattern ' install\.ps1$').Line.Split(' ')[0]
+(Get-FileHash install.ps1 -Algorithm SHA256).Hash -eq $expected.ToUpper()
+
+.\install.ps1
+```
+
+The comparison prints `True` if the script matches. To also check the signature, install
+[Gpg4win](https://gpg4win.org) and run the same `gpg --verify` command as above.
+
+### The pnpm release key
+
+| | Fingerprint |
+| --- | --- |
+| Primary key | `4D20AD76D7BE567214F3F8EE4EABAE7510A044FA` |
+| Signing subkey | `432EDF21183B9FE186AA53247CBF6055273E6CB5` |
+
+The key is published on [keys.openpgp.org](https://keys.openpgp.org/search?q=4D20AD76D7BE567214F3F8EE4EABAE7510A044FA)
+and on [Keybase](https://keybase.io/pnpm/pgp_keys.asc). Both serve the same key, so either
+source works:
+
+```sh
+curl -fsSL https://keybase.io/pnpm/pgp_keys.asc | gpg --import
+```
+
+`SHASUMS256.txt` covers the installer scripts served from this site. The pnpm executable
+itself is downloaded by the installer from the pnpm release for the version being installed.
 
 ## Configuring
 


### PR DESCRIPTION
## Summary

The "Verifying files" section demonstrated `v6.16.js` — the pnpm 6-era installer — so anyone following it verified a file they weren't going to run. It now walks through `install.sh` end to end, and adds the PowerShell equivalent for `install.ps1`, which had no verification instructions at all.

```sh
curl -fsSLO https://get.pnpm.io/install.sh
curl -fsSLO https://get.pnpm.io/SHASUMS256.txt
curl -fsSLO https://get.pnpm.io/SHASUMS256.txt.sig

curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/4D20AD76D7BE567214F3F8EE4EABAE7510A044FA | gpg --import

gpg --verify SHASUMS256.txt.sig SHASUMS256.txt \
  && grep ' install.sh$' SHASUMS256.txt | sha256sum -c - \
  && sh install.sh
```

The steps are chained so the installer is never reached unless both checks pass, and the PowerShell flow throws instead of falling through. Every command in the PR was run verbatim against the live site before writing it: the signature verifies (`Good signature`, primary `4D20AD76D7BE567214F3F8EE4EABAE7510A044FA`, subkey `432EDF…`), and the published checksum matches the live `install.sh` under both `sha256sum` and macOS's `shasum -a 256`. Tampering with either input was also tested: a modified `install.sh` fails the checksum and an extra line in `SHASUMS256.txt` fails the signature, and neither reaches the installer.

Other changes:

- **Key import points at keys.openpgp.org with the fingerprint pinned**, rather than only at Keybase. Both now serve the same key, but the fingerprint is the thing a user can compare out of band, and an account-independent keyserver is one fewer name to trust. Keybase is kept as an alternative source.
- **The fingerprints are published in the README**, so the import step has something to check against. Telling people to import a key without telling them which key is the part that made the old instructions ceremonial.
- **The `WARNING: The key's User ID is not certified with a trusted signature` line is called out as expected output.** It is the most common reason people conclude verification failed when it actually succeeded.
- **Linked from the Usage section.** Verification instructions nobody reaches protect nobody, and the one-liners are what people copy.
- **Notes the scope of the checksums** — they cover the installer scripts served from this site, not the pnpm executable the installer downloads.

## Follow-ups, not in this PR

- The executable the installer downloads isn't verified at all. Extending the checks to it — either by covering the release assets in `SHASUMS256.txt`, or by having `install.sh` check the tarball against the registry's `dist.integrity`, which it can reach since it already fetches the packument to resolve the version — would close the remaining gap. Happy to do that next.
- `_update.sh` signs with `--local-user pnpm`, so the signature's signer-user-ID subpacket names `pnpm@kochan.io`. Adding `--sender gpg@pnpm.io` would make future signatures report the project address instead. Left alone here so the documented output matches what the current signature actually prints.
- pnpm.io/installation shows the bare one-liner and should link to this section.

---
Written by an agent (Claude Code, claude-opus-5).
