### PR TITLE
feat: let a caller waive the signature check on an executable download

### DIFF
--- a/get-pnpm/README.md
+++ b/get-pnpm/README.md
@@ -82,6 +82,12 @@ It verifies exactly what the other two do, and reads the archive in-process
 rather than shelling out to `tar`, so it works where no `tar` is on the PATH.
 Placement is atomic and tolerates losing a race with a concurrent call.
 
+Pass `keys` to trust a signing key other than the pinned npm one, or
+`verifySignature: false` to download from a registry that carries no npm
+signatures at all — a private mirror that re-published the package. The checksum
+is still enforced either way; what is lost is the assurance that it came from
+somewhere other than the host that served the bytes.
+
 ## Development
 
 ```sh

--- a/get-pnpm/src/downloadExecutable.ts
+++ b/get-pnpm/src/downloadExecutable.ts
@@ -24,8 +24,17 @@ export interface DownloadExecutableOptions {
   destPath: string
   /** Credentials for `registry`, withheld from any other origin. */
   headers?: RequestHeaders
-  /** Overrides the pinned npm signing keys; for tests. */
+  /** Overrides the pinned npm signing keys. */
   keys?: readonly SigningKey[]
+  /**
+   * Whether the registry's signature over the checksum has to check out.
+   *
+   * Only a caller downloading from a registry that does not carry npm's
+   * signatures — a private mirror that re-published the package — has any
+   * business turning this off, and only having accepted that the checksum then
+   * comes from the same place as the bytes it vouches for. Defaults to `true`.
+   */
+  verifySignature?: boolean
 }
 
 /**
@@ -39,7 +48,9 @@ export interface DownloadExecutableOptions {
  *
  * The download is checked against the checksum the registry published for it,
  * and that checksum against npm's signature, exactly as {@link downloadPnpm}
- * does. Nothing is written to `destPath` until both pass.
+ * does. Nothing is written to `destPath` until both pass — unless the caller
+ * waived the signature, which is a decision only it can make; see
+ * {@link DownloadExecutableOptions.verifySignature}.
  *
  * Placement is atomic and tolerates losing a race: a concurrent call that got
  * there first keeps its copy, since both placed the same verified bytes.
@@ -60,13 +71,15 @@ export async function downloadPnpmExecutable (opts: DownloadExecutableOptions): 
   if (!meta.dist.integrity) {
     throw new Error(`The npm registry published no checksum for ${packageName}@${version}, so it cannot be verified.`)
   }
-  verifyRegistrySignature({
-    name: packageName,
-    version,
-    integrity: meta.dist.integrity,
-    signatures: meta.dist.signatures,
-    keys: opts.keys,
-  })
+  if (opts.verifySignature !== false) {
+    verifyRegistrySignature({
+      name: packageName,
+      version,
+      integrity: meta.dist.integrity,
+      signatures: meta.dist.signatures,
+      keys: opts.keys,
+    })
+  }
 
   const scratch = `${destPath}.${randomBytes(6).toString('hex')}`
   const tarball = `${scratch}.tgz`

--- a/get-pnpm/src/downloadExecutable.ts
+++ b/get-pnpm/src/downloadExecutable.ts
@@ -27,12 +27,10 @@ export interface DownloadExecutableOptions {
   /** Overrides the pinned npm signing keys. */
   keys?: readonly SigningKey[]
   /**
-   * Whether the registry's signature over the checksum has to check out.
-   *
-   * Only a caller downloading from a registry that does not carry npm's
-   * signatures — a private mirror that re-published the package — has any
-   * business turning this off, and only having accepted that the checksum then
-   * comes from the same place as the bytes it vouches for. Defaults to `true`.
+   * Whether the registry's signature over the checksum has to check out;
+   * `true` unless set. Waiving it is for a registry that carries no npm
+   * signatures — one that re-published the package — and accepts that the
+   * checksum then comes from the same host as the bytes it vouches for.
    */
   verifySignature?: boolean
 }
@@ -48,9 +46,8 @@ export interface DownloadExecutableOptions {
  *
  * The download is checked against the checksum the registry published for it,
  * and that checksum against npm's signature, exactly as {@link downloadPnpm}
- * does. Nothing is written to `destPath` until both pass — unless the caller
- * waived the signature, which is a decision only it can make; see
- * {@link DownloadExecutableOptions.verifySignature}.
+ * does; nothing is written to `destPath` until both pass. See
+ * {@link DownloadExecutableOptions.verifySignature} for the one waiver.
  *
  * Placement is atomic and tolerates losing a race: a concurrent call that got
  * there first keeps its copy, since both placed the same verified bytes.

--- a/get-pnpm/test/downloadExecutable.test.ts
+++ b/get-pnpm/test/downloadExecutable.test.ts
@@ -24,7 +24,7 @@ const KEYS: SigningKey[] = [{
 }]
 
 /** One thing broken per run, to drive each refusal separately. */
-type Mode = 'ok' | 'bad-tarball' | 'bad-signature' | 'no-integrity' | 'no-executable' | 'npm-tarball-url' | 'truncated'
+type Mode = 'ok' | 'bad-tarball' | 'bad-signature' | 'unsigned' | 'no-integrity' | 'no-executable' | 'npm-tarball-url' | 'truncated'
 
 let tmpDir: string
 let server: http.Server
@@ -82,10 +82,12 @@ describe('downloadPnpmExecutable', () => {
               ? `https://registry.npmjs.org/${name}/-/tarball.tgz`
               : `${addressOf(cdn)}/${name}/-/tarball.tgz`,
             ...(mode === 'no-integrity' ? {} : { integrity }),
-            signatures: [{
-              keyid: KEYS[0]!.keyid,
-              sig: createSign('SHA256').update(`${name}@${VERSION}:${signed}`).sign(privateKey, 'base64'),
-            }],
+            signatures: mode === 'unsigned'
+              ? []
+              : [{
+                keyid: KEYS[0]!.keyid,
+                sig: createSign('SHA256').update(`${name}@${VERSION}:${signed}`).sign(privateKey, 'base64'),
+              }],
           },
         }))
         return
@@ -202,6 +204,31 @@ describe('downloadPnpmExecutable', () => {
 
     await assert.rejects(download(destPath), /is not valid/)
     assert.deepEqual(fs.readdirSync(path.dirname(destPath)), [])
+  })
+
+  test('refuses an unsigned package', async () => {
+    mode = 'unsigned'
+
+    await assert.rejects(download(destIn('unsigned')), /carries no npm registry signature/)
+  })
+
+  test('takes an unsigned package when the caller waives the signature', async () => {
+    mode = 'unsigned'
+    const destPath = destIn('signature-waived')
+
+    await downloadPnpmExecutable({ version: VERSION, registry, destPath, verifySignature: false })
+
+    assert.equal(fs.readFileSync(destPath, 'utf8'), CONTENT)
+  })
+
+  test('still checks the checksum when the caller waives the signature', async () => {
+    mode = 'bad-tarball'
+    const destPath = destIn('waived-but-tampered')
+
+    await assert.rejects(
+      downloadPnpmExecutable({ version: VERSION, registry, destPath, verifySignature: false }),
+      /does not match the checksum/
+    )
   })
 
   test('refuses a package the registry published no checksum for', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #52, needed before pnpm's Corepack entry point (pnpm/pnpm#13922) can use `downloadPnpmExecutable`.

Corepack's signature policy has three states, all through `COREPACK_INTEGRITY_KEYS`:

| Value | Corepack behaviour |
| --- | --- |
| unset | npm's pinned keys; signature required |
| a JSON key set | those keys; signature required |
| `0` or empty | signature verification skipped entirely ([`shouldSkipIntegrityCheck`](https://github.com/nodejs/corepack/blob/main/sources/corepackUtils.ts)) |

The first two are expressible today (`keys`); the third is not. That matters because the third state is not hypothetical: a registry that re-publishes packages carries no npm signatures, and a user on one has already had to set `COREPACK_INTEGRITY_KEYS=0` for Corepack to install the `pnpm` wrapper from it at all. Without a waiver here, the executable download would then fail where the wrapper install just succeeded, under a stricter rule than Corepack applies to itself.

So: `verifySignature: false`. **The checksum stays mandatory in every case** — what the waiver gives up is the assurance that the checksum came from somewhere other than the host that served the bytes, which is the caller's call to make.

## Testing

Three new tests: an unsigned package is refused by default, taken when the caller waives it, and a tampered tarball is still refused with the waiver in place. Full suite: 47 passing.

---
Written by an agent (Claude Code, claude-opus-5).
