### PR TITLE
fix: fetch the release key from keys.openpgp.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,11 @@ other. The signature is what ties them to the pnpm release key.
 | Primary key | `4D20AD76D7BE567214F3F8EE4EABAE7510A044FA` |
 | Signing subkey | `432EDF21183B9FE186AA53247CBF6055273E6CB5` |
 
-The key is published on [keys.openpgp.org](https://keys.openpgp.org/search?q=4D20AD76D7BE567214F3F8EE4EABAE7510A044FA)
-and on [Keybase](https://keybase.io/pnpm/pgp_keys.asc). Both serve the same key, so either
-source works:
+The key is published on [keys.openpgp.org](https://keys.openpgp.org/search?q=4D20AD76D7BE567214F3F8EE4EABAE7510A044FA),
+which serves it by either fingerprint above:
 
 ```sh
-curl -fsSL https://keybase.io/pnpm/pgp_keys.asc | gpg --import
+curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/4D20AD76D7BE567214F3F8EE4EABAE7510A044FA | gpg --import
 ```
 
 `SHASUMS256.txt` lists the installer scripts served from this site — `install.sh`,

--- a/_check.sh
+++ b/_check.sh
@@ -7,5 +7,5 @@ grep v6.16.js SHASUMS256.txt | sha256sum -c -
 grep v6.32.js SHASUMS256.txt | sha256sum -c -
 grep install.sh SHASUMS256.txt | sha256sum -c -
 grep install.ps1 SHASUMS256.txt | sha256sum -c -
-curl https://keybase.io/pnpm/pgp_keys.asc | gpg --import
+curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/4D20AD76D7BE567214F3F8EE4EABAE7510A044FA | gpg --import
 gpg --verify SHASUMS256.txt.sig SHASUMS256.txt


### PR DESCRIPTION
`Verify integrity` fails on every push right now, `main` included — it is not specific to any PR.

## Why

`_check.sh` fetched the release key from Keybase:

```sh
curl https://keybase.io/pnpm/pgp_keys.asc | gpg --import
```

That URL now answers **404** with a 32-byte body:

```
SELF-SIGNED PUBLIC KEY NOT FOUND
```

There was no `-f`, so the 404 page was piped into `gpg --import`, which reported `no valid OpenPGP data found` and exited 2 — a confusing way to say the key could not be downloaded. The keybase.io/pnpm account still exists and its API still returns key bundles; only that endpoint stopped serving a self-signed key. The last green run was 2026-08-15.

## The change

keys.openpgp.org serves the same key, by either fingerprint the README documents. `-f` is added so the next host to stop serving it fails as a download error rather than as a bogus gpg error.

`README.md` pointed users at the dead Keybase URL too, and said the two sources both work; it now shows the one that does. No re-signing is needed — `SHASUMS256.txt` covers only the installer scripts, and neither file here is one.

## Verification

`sh ./_check.sh` against an **empty** `GNUPGHOME`, so nothing already in a local keyring can carry it:

```
install.sh: OK
install.ps1: OK
gpg: key 4EABAE7510A044FA: public key "pnpm <pnpm@kochan.io>" imported
gpg: Good signature from "pnpm <pnpm@kochan.io>"
Primary key fingerprint: 4D20 AD76 D7BE 5672 14F3  F8EE 4EAB AE75 10A0 44FA
     Subkey fingerprint: 432E DF21 183B 9FE1 86AA  5324 7CBF 6055 273E 6CB5
```

Both match the fingerprint table in `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release key instructions to use keys.openpgp.org and fingerprint-based retrieval.
  * Removed references to the previous Keybase source.

* **Chores**
  * Updated verification tooling to import the release key from keys.openpgp.org before checking signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->