### PR TITLE
fix: download through the proxy the environment names

### DIFF
--- a/get-pnpm/README.md
+++ b/get-pnpm/README.md
@@ -41,6 +41,7 @@ The download goes to the registry npm is configured with (`npm_config_registry`)
 | `PNPM_VERSION` | Version to install when no argument is given. |
 | `PNPM_HOME` | Directory to install pnpm into. |
 | `npm_config_registry` | Registry to download pnpm from. |
+| `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` | Proxy to download through, and hosts to reach directly. Applied on Node 24.14 and later; earlier releases go direct. |
 
 ## Using it from a program
 

--- a/get-pnpm/src/downloadExecutable.ts
+++ b/get-pnpm/src/downloadExecutable.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import { extractTarballMember } from './extractTarballMember.js'
 import { isMusl, platformPackageName } from './platformPackageName.js'
-import { downloadTarball, fetchVersionMeta, normalizeRegistry, type RequestHeaders } from './registry.js'
+import { downloadTarball, fetchVersionMeta, normalizeRegistry, type RequestHeaders, useProxyFromEnv } from './registry.js'
 import { majorVersion } from './resolveVersion.js'
 import { sameFileContents } from './sameFileContents.js'
 import { type SigningKey, verifyRegistrySignature } from './verifySignature.js'
@@ -55,15 +55,26 @@ export interface DownloadExecutableOptions {
  * @returns the package the executable came from.
  */
 export async function downloadPnpmExecutable (opts: DownloadExecutableOptions): Promise<{ packageName: string }> {
-  const { version, destPath } = opts
   const registry = normalizeRegistry(opts.registry)
   const packageName = platformPackageName({
-    major: majorVersion(version),
+    major: majorVersion(opts.version),
     platform: process.platform,
     arch: process.arch,
     musl: isMusl(),
   })
 
+  const restoreProxy = useProxyFromEnv()
+  try {
+    return await fetchExecutable({ ...opts, registry, packageName })
+  } finally {
+    restoreProxy()
+  }
+}
+
+async function fetchExecutable (
+  opts: DownloadExecutableOptions & { packageName: string }
+): Promise<{ packageName: string }> {
+  const { version, destPath, registry, packageName } = opts
   const meta = await fetchVersionMeta(registry, packageName, version, opts.headers)
   if (!meta.dist.integrity) {
     throw new Error(`The npm registry published no checksum for ${packageName}@${version}, so it cannot be verified.`)

--- a/get-pnpm/src/index.ts
+++ b/get-pnpm/src/index.ts
@@ -5,14 +5,14 @@ import path from 'node:path'
 
 import { extractTarball } from './extractTarball.js'
 import { isMusl, platformPackageName } from './platformPackageName.js'
-import { downloadTarball, fetchPackument, fetchVersionMeta, registryFromEnv } from './registry.js'
+import { downloadTarball, fetchPackument, fetchVersionMeta, registryFromEnv, useProxyFromEnv } from './registry.js'
 import { majorVersion, resolveVersion } from './resolveVersion.js'
 import { type SigningKey, verifyRegistrySignature } from './verifySignature.js'
 
 export { type DownloadExecutableOptions, downloadPnpmExecutable } from './downloadExecutable.js'
 export { extractTarballMember } from './extractTarballMember.js'
 export { isMusl, platformPackageName, type Target } from './platformPackageName.js'
-export { DEFAULT_REGISTRY, registryFromEnv, type RequestHeaders } from './registry.js'
+export { DEFAULT_REGISTRY, registryFromEnv, type RequestHeaders, useProxyFromEnv } from './registry.js'
 export { type Packument, majorVersion, resolveVersion } from './resolveVersion.js'
 export { type PackageSignature, type SigningKey, verifyRegistrySignature } from './verifySignature.js'
 
@@ -43,6 +43,8 @@ Environment variables:
   PNPM_VERSION           Version to install when no argument is given.
   PNPM_HOME              Directory to install pnpm into.
   npm_config_registry    Registry to download pnpm from.
+  HTTPS_PROXY            Proxy to download through; NO_PROXY names hosts to
+                         reach directly. Node 24.14 or later.
 `
 
 export async function runCli (argv: string[]): Promise<number> {
@@ -126,6 +128,22 @@ export async function installPnpm (
  * @returns the version installed and the path to the executable.
  */
 export async function downloadPnpm (
+  opts: {
+    versionSpec: string
+    registry: string
+    dest: string
+    keys?: readonly SigningKey[]
+  }
+): Promise<{ version: string, binPath: string }> {
+  const restoreProxy = useProxyFromEnv()
+  try {
+    return await fetchPnpm(opts)
+  } finally {
+    restoreProxy()
+  }
+}
+
+async function fetchPnpm (
   opts: {
     versionSpec: string
     registry: string

--- a/get-pnpm/src/index.ts
+++ b/get-pnpm/src/index.ts
@@ -43,8 +43,9 @@ Environment variables:
   PNPM_VERSION           Version to install when no argument is given.
   PNPM_HOME              Directory to install pnpm into.
   npm_config_registry    Registry to download pnpm from.
-  HTTPS_PROXY            Proxy to download through; NO_PROXY names hosts to
-                         reach directly. Node 24.14 or later.
+  HTTPS_PROXY            Proxy to download through (HTTP_PROXY for an http://
+                         registry); NO_PROXY names hosts to reach directly.
+                         Node 24.14 or later.
 `
 
 export async function runCli (argv: string[]): Promise<number> {

--- a/get-pnpm/src/registry.ts
+++ b/get-pnpm/src/registry.ts
@@ -67,7 +67,10 @@ export function useProxyFromEnv (): () => void {
   if (!PROXY_VARS.some((name) => process.env[name])) return () => {}
   const { setGlobalProxyFromEnv } = http as ProxyCapableHttp
   if (setGlobalProxyFromEnv == null) return () => {}
-  if (proxyUsers++ === 0) restoreProxy = setGlobalProxyFromEnv(process.env)
+  // Counted only once the activation took: a call that threw on a malformed
+  // proxy URL holds nothing to release, and a retry after a fix has to activate.
+  if (proxyUsers === 0) restoreProxy = setGlobalProxyFromEnv(process.env)
+  proxyUsers++
   let released = false
   return () => {
     if (released) return

--- a/get-pnpm/src/registry.ts
+++ b/get-pnpm/src/registry.ts
@@ -58,13 +58,26 @@ type ProxyCapableHttp = typeof http & {
  *
  * Node before 24.14 has no way to apply the proxy after startup, so the
  * request goes direct there, as it always has.
+ *
+ * The setting is process-global, so overlapping downloads share one
+ * activation: the first call applies the proxy and the last of the returned
+ * functions to run puts the agents back, never one in the middle.
  */
 export function useProxyFromEnv (): () => void {
   if (!PROXY_VARS.some((name) => process.env[name])) return () => {}
   const { setGlobalProxyFromEnv } = http as ProxyCapableHttp
   if (setGlobalProxyFromEnv == null) return () => {}
-  return setGlobalProxyFromEnv(process.env)
+  if (proxyUsers++ === 0) restoreProxy = setGlobalProxyFromEnv(process.env)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    if (--proxyUsers === 0) restoreProxy()
+  }
 }
+
+let proxyUsers = 0
+let restoreProxy: () => void = () => {}
 
 // Node's fetch applies no timeout of its own: a registry that accepts the
 // connection and then stalls would hang the install with no output. Metadata is

--- a/get-pnpm/src/registry.ts
+++ b/get-pnpm/src/registry.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { createWriteStream } from 'node:fs'
+import http from 'node:http'
 import { pipeline } from 'node:stream/promises'
 
 import type { Packument } from './resolveVersion.js'
@@ -33,6 +34,36 @@ export function registryFromEnv (): string {
  */
 export function normalizeRegistry (registry: string): string {
   return registry.endsWith('/') ? registry : `${registry}/`
+}
+
+const PROXY_VARS = ['https_proxy', 'HTTPS_PROXY', 'http_proxy', 'HTTP_PROXY'] as const
+
+// `http.setGlobalProxyFromEnv` arrived in Node 24.14; the types this package
+// builds against predate it.
+type ProxyCapableHttp = typeof http & {
+  setGlobalProxyFromEnv?: (proxyEnv?: NodeJS.ProcessEnv) => () => void
+}
+
+/**
+ * Routes every request made until the returned function is called through the
+ * proxy the environment names in `HTTPS_PROXY`/`HTTP_PROXY`, honouring
+ * `NO_PROXY`. A no-op when the environment names none.
+ *
+ * `fetch` reads those variables only when Node was started with
+ * `NODE_USE_ENV_PROXY=1`, which nothing that embeds this package controls:
+ * Corepack starts the process that runs pnpm's launcher. On a network that
+ * allows no other route out, the download then fails with a bare
+ * `fetch failed`, while everything before it went through the proxy fine,
+ * Corepack's own download of the `pnpm` package included.
+ *
+ * Node before 24.14 has no way to apply the proxy after startup, so the
+ * request goes direct there, as it always has.
+ */
+export function useProxyFromEnv (): () => void {
+  if (!PROXY_VARS.some((name) => process.env[name])) return () => {}
+  const { setGlobalProxyFromEnv } = http as ProxyCapableHttp
+  if (setGlobalProxyFromEnv == null) return () => {}
+  return setGlobalProxyFromEnv(process.env)
 }
 
 // Node's fetch applies no timeout of its own: a registry that accepts the

--- a/get-pnpm/test/downloadExecutable.test.ts
+++ b/get-pnpm/test/downloadExecutable.test.ts
@@ -201,6 +201,21 @@ describe('downloadPnpmExecutable', () => {
     assert.deepEqual(proxyRequests, [], 'a request after the download went direct')
   })
 
+  test('keeps the proxy until the last of two overlapping downloads is done', { skip: PROXY_UNSUPPORTED }, async () => {
+    // Every request the first download makes goes through the proxy even after
+    // the second finishes; the direct route comes back only once both are done.
+    let proxied = 0
+    await withEnv({ HTTP_PROXY: addressOf(proxy), NO_PROXY: undefined }, async () => {
+      await Promise.all([download(destIn('overlap-a')), download(destIn('overlap-b'))])
+      proxied = proxyRequests.length
+      proxyRequests = []
+      await fetch(`${registry}${packageNameFor()}/${VERSION}`)
+    })
+
+    assert.equal(proxied, 4, 'both metadata requests and both downloads went through the proxy')
+    assert.deepEqual(proxyRequests, [], 'a request after both downloads went direct')
+  })
+
   test('re-hosts an npm tarball URL onto the registry that served the metadata', async () => {
     mode = 'npm-tarball-url'
     const destPath = destIn('rehosted')

--- a/get-pnpm/test/downloadExecutable.test.ts
+++ b/get-pnpm/test/downloadExecutable.test.ts
@@ -216,6 +216,20 @@ describe('downloadPnpmExecutable', () => {
     assert.deepEqual(proxyRequests, [], 'a request after both downloads went direct')
   })
 
+  test('activates the proxy on a retry after a malformed proxy URL was rejected', { skip: PROXY_UNSUPPORTED }, async () => {
+    await withEnv({ HTTP_PROXY: 'not a url', NO_PROXY: undefined }, async () => {
+      await assert.rejects(download(destIn('malformed')))
+    })
+    const destPath = destIn('retried')
+
+    await withEnv({ HTTP_PROXY: addressOf(proxy), NO_PROXY: undefined }, async () => {
+      await download(destPath)
+    })
+
+    assert.equal(fs.readFileSync(destPath, 'utf8'), CONTENT)
+    assert.equal(proxyRequests.length, 2, 'the retry went through the proxy')
+  })
+
   test('re-hosts an npm tarball URL onto the registry that served the metadata', async () => {
     mode = 'npm-tarball-url'
     const destPath = destIn('rehosted')

--- a/get-pnpm/test/downloadExecutable.test.ts
+++ b/get-pnpm/test/downloadExecutable.test.ts
@@ -29,10 +29,16 @@ type Mode = 'ok' | 'bad-tarball' | 'bad-signature' | 'unsigned' | 'no-integrity'
 let tmpDir: string
 let server: http.Server
 let cdn: http.Server
+let proxy: http.Server
 let registry: string
 let mode: Mode = 'ok'
 let requests: Array<{ path: string, authorization?: string }> = []
 let cdnRequests: Array<{ path: string, authorization?: string }> = []
+let proxyRequests: string[] = []
+
+// Node applies a proxy after startup from 24.14; before that the request goes
+// direct, which the proxy tests have nothing to say about.
+const PROXY_UNSUPPORTED = typeof (http as { setGlobalProxyFromEnv?: unknown }).setGlobalProxyFromEnv !== 'function'
 
 describe('downloadPnpmExecutable', () => {
   before(async () => {
@@ -96,10 +102,25 @@ describe('downloadPnpmExecutable', () => {
     })
     await listen(server)
     registry = `${addressOf(server)}/`
+
+    // A forwarding proxy: a client that routes through it asks for the full
+    // URL, which is relayed to the origin it names. The relay gets an agent of
+    // its own, since the global one is what the code under test points at the
+    // proxy, and the relay would otherwise loop back through it to itself.
+    proxy = http.createServer((req, res) => {
+      proxyRequests.push(req.url!)
+      const target = new URL(req.url!)
+      const relay = http.request(target, { method: req.method, headers: req.headers, agent: new http.Agent() }, (upstream) => {
+        res.writeHead(upstream.statusCode!, upstream.headers)
+        upstream.pipe(res)
+      })
+      req.pipe(relay)
+    })
+    await listen(proxy)
   })
 
   after(async () => {
-    await Promise.all([close(server), close(cdn)])
+    await Promise.all([close(server), close(cdn), close(proxy)])
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
@@ -107,6 +128,7 @@ describe('downloadPnpmExecutable', () => {
     mode = 'ok'
     requests = []
     cdnRequests = []
+    proxyRequests = []
   })
 
   test('places the executable and nothing else', async () => {
@@ -140,6 +162,43 @@ describe('downloadPnpmExecutable', () => {
 
     assert.equal(requests[0]!.authorization, 'Bearer a-token')
     assert.equal(cdnRequests[0]!.authorization, undefined)
+  })
+
+  test('routes the download through the proxy the environment names', { skip: PROXY_UNSUPPORTED }, async () => {
+    const destPath = destIn('proxied')
+
+    await withEnv({ HTTP_PROXY: addressOf(proxy), NO_PROXY: undefined }, async () => {
+      await download(destPath)
+    })
+
+    assert.equal(fs.readFileSync(destPath, 'utf8'), CONTENT)
+    assert.deepEqual(proxyRequests, [
+      `${registry}${packageNameFor()}/${VERSION}`,
+      `${addressOf(cdn)}/${packageNameFor()}/-/tarball.tgz`,
+    ])
+    assert.equal(requests.length, 1, 'the registry was reached through the proxy')
+    assert.equal(cdnRequests.length, 1, 'the download host was reached through the proxy')
+  })
+
+  test('leaves the proxy alone for a host NO_PROXY excludes', { skip: PROXY_UNSUPPORTED }, async () => {
+    const destPath = destIn('unproxied')
+
+    await withEnv({ HTTP_PROXY: addressOf(proxy), NO_PROXY: '127.0.0.1' }, async () => {
+      await download(destPath)
+    })
+
+    assert.equal(fs.readFileSync(destPath, 'utf8'), CONTENT)
+    assert.deepEqual(proxyRequests, [])
+  })
+
+  test('stops using the proxy once the download is done', { skip: PROXY_UNSUPPORTED }, async () => {
+    await withEnv({ HTTP_PROXY: addressOf(proxy), NO_PROXY: undefined }, async () => {
+      await download(destIn('restored'))
+      proxyRequests = []
+      await fetch(`${registry}${packageNameFor()}/${VERSION}`)
+    })
+
+    assert.deepEqual(proxyRequests, [], 'a request after the download went direct')
   })
 
   test('re-hosts an npm tarball URL onto the registry that served the metadata', async () => {
@@ -245,6 +304,24 @@ describe('downloadPnpmExecutable', () => {
     assert.deepEqual(fs.readdirSync(path.dirname(destPath)), [])
   })
 })
+
+/** Runs `fn` with the proxy variables set as given, then puts them back. */
+async function withEnv (vars: Record<string, string | undefined>, fn: () => Promise<void>): Promise<void> {
+  const names = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'no_proxy']
+  const saved = Object.fromEntries(names.map((name) => [name, process.env[name]]))
+  for (const name of names) delete process.env[name]
+  for (const [name, value] of Object.entries(vars)) {
+    if (value !== undefined) process.env[name] = value
+  }
+  try {
+    await fn()
+  } finally {
+    for (const name of names) {
+      if (saved[name] === undefined) delete process.env[name]
+      else process.env[name] = saved[name]
+    }
+  }
+}
 
 async function download (destPath: string): Promise<unknown> {
   return downloadPnpmExecutable({ version: VERSION, registry, destPath, keys: KEYS })


### PR DESCRIPTION
Fixes #57.

### Problem

`get-pnpm` downloads with Node's global `fetch()`, which reads `HTTPS_PROXY`, `HTTP_PROXY` and `NO_PROXY` only when the process was started with `NODE_USE_ENV_PROXY=1`. Nothing that embeds this package controls that: Corepack starts the process that runs pnpm 12's launcher. On a network with no other route out, Corepack fetches the `pnpm` package through the proxy and the launcher's follow-up download of the native binary then fails with a bare `fetch failed`. Dependabot is one such network; a public log is linked from #57.

### Fix

Apply the proxy at runtime with `http.setGlobalProxyFromEnv()`, added in Node 24.14, for the duration of `downloadPnpm` and `downloadPnpmExecutable`, and only when the environment names a proxy. The returned restore function puts the global agents back afterwards, so a caller using this as a library sees no change to its own requests. No dependency is added.

Node before 24.14 has no way to apply the proxy after startup, so the request keeps going direct there, exactly as today. The `engines` range is unchanged.

### Tests

Three tests in `downloadExecutable.test.ts` run a small forwarding proxy and check that both the metadata request and the tarball download go through it, that `NO_PROXY` bypasses it, and that a request after the download goes direct again. They are skipped on a Node without the API, which the Node 22 CI cell exercises.

End-to-end, with the built `lib/` dropped into a Corepack-cached `pnpm@12.2.1` and its native binary removed:

| Proxy | Result |
|---|---|
| dead proxy on `127.0.0.1:9` | `Could not reach https://registry.npmjs.org/@pnpm/exe.darwin-arm64/12.2.1: fetch failed` |
| local CONNECT proxy | binary downloaded; the proxy logged `CONNECT registry.npmjs.org:443` |
| none | binary downloaded directly |

Without this change the first row succeeds by bypassing the proxy, which is the failure mode on a proxy-only network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package metadata and executable downloads can use proxies configured through `HTTPS_PROXY` or `HTTP_PROXY`.
  * Honors `NO_PROXY` exclusions and restores normal network behavior after downloads complete.
  * Added a public helper for configuring proxy support in integrations, including overlapping downloads.

* **Documentation**
  * Documented proxy environment variables and CLI usage.
  * Clarified that proxy support applies to Node.js 24.14 and later; earlier versions connect directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->